### PR TITLE
Check for approved comments

### DIFF
--- a/inc/class-comment-hacks.php
+++ b/inc/class-comment-hacks.php
@@ -81,9 +81,10 @@ class YoastCommentHacks {
 	 * @return string $url the URL to be redirected to, altered if this was a first time comment.
 	 */
 	public function comment_redirect( $url, $comment ) {
-		$comment_count = get_comments( array( 'author_email' => $comment->comment_author_email, 'count' => true ) );
+		$has_approved_comment = get_comments( array( 'author_email' => $comment->comment_author_email, 'number' => 1, 'status' => 'approve' ) );
 
-		if ( 1 == $comment_count ) {
+		// If no approved comments have been found, show the thank-you page.
+		if ( empty( $has_approved_comment ) ) {
 			// Only change $url when the page option is actually set and not zero
 			if ( isset( $this->options['redirect_page'] ) && 0 != $this->options['redirect_page'] ) {
 				$url = get_permalink( $this->options['redirect_page'] );


### PR DESCRIPTION
Instead of checking for 'a comment' to be in the system (draft, unapproved) checking for approved comments has a more natural experience for the user.

Situation:
- Visitor enters a comment
- Shown the thank-you page
- Adds another comment without being approved yet
- Returns to the page with the #{comment-id} hash, but the comment is not there yet (not approved)

Feels like something went wrong.
