### PR TITLE
Adds span to the comment-policy sentence

### DIFF
--- a/inc/class-comment-form-hacks.php
+++ b/inc/class-comment-form-hacks.php
@@ -31,7 +31,7 @@ class YoastCommentFormHacks {
 	 * @return array
 	 */
 	public function filter_defaults( $defaults ) {
-		$defaults['comment_notes_before'] = 'You have to agree to the comment policy.';
+		$defaults['comment_notes_before'] = '<span class="agree-comment-policy">You have to agree to the comment policy.</span>';
 
 		return $defaults;
 	}


### PR DESCRIPTION
To make sure we can place and style the comment, It adds a span with a class.

# How to test
1. check out the branch
2. check if the span is visible when trying to comment on a post.
3. it should not change the design in any way. 