### PR TITLE
Documentation: improve action/filter hook documentation

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -110,7 +110,10 @@ class YoastCommentHacksAdmin {
 		$post_id = filter_input( INPUT_GET, 'post', FILTER_VALIDATE_INT );
 
 		/**
-		 * This filter allows filtering which roles should be shown in the dropdown for notifications. Defaults to contributor and up.
+		 * This filter allows filtering which roles should be shown in the dropdown for notifications.
+		 * Defaults to contributor and up.
+		 *
+		 * @param array $roles Array with user roles.
 		 */
 		$roles = apply_filters(
 			'yoast_comment_hacks_notification_roles',

--- a/admin/views/config-page.php
+++ b/admin/views/config-page.php
@@ -181,4 +181,8 @@ $option_name = esc_attr( YoastCommentHacks::$option_name );
 	</div>
 
 <?php
+/**
+ * Action hook to allow other plugins to add additional information to the
+ * Yoast Comment Hacks admin page.
+ */
 do_action( 'yoast_ch_admin_footer' );

--- a/inc/class-comment-hacks.php
+++ b/inc/class-comment-hacks.php
@@ -85,7 +85,13 @@ class YoastCommentHacks {
 			if ( isset( $this->options['redirect_page'] ) && 0 != $this->options['redirect_page'] ) {
 				$url = get_permalink( $this->options['redirect_page'] );
 
-				// Allow other plugins to hook when the user is being redirected, for analytics calls or even to change the target URL.
+				/**
+				 * Allow other plugins to hook in when the user is being redirected,
+				 * for analytics calls or even to change the target URL.
+				 *
+				 * @param string $url     URL to which the first-time commenter will be redirected.
+				 * @param object $comment The comment object.
+				 */
 				$url = apply_filters( 'yoast_comment_redirect', $url, $comment );
 			}
 		}


### PR DESCRIPTION
Hooks should be documented using a docblock which includes a summary, an optional description and information on the parameters passed.
Ref: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#4-hooks-actions-and-filters