### PR TITLE
Documentation: use consistent package names

### DIFF
--- a/admin/views/comment-parent-box.php
+++ b/admin/views/comment-parent-box.php
@@ -2,7 +2,7 @@
 /**
  * Parent Box view.
  *
- * @package yoast_comment_hacks\admin
+ * @package YoastCommentHacks\admin
  */
 
 ?>

--- a/admin/views/config-page.php
+++ b/admin/views/config-page.php
@@ -2,7 +2,7 @@
 /**
  * Config page admin view.
  *
- * @package yoast_comment_hacks\admin
+ * @package YoastCommentHacks\admin
  */
 
 $option_name = esc_attr( YoastCommentHacks::$option_name );


### PR DESCRIPTION
These were the two odd ones out while the tag in all the other files is consistent.