### PR TITLE
CS: load script in a non-page-render-blocking manner

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -87,8 +87,21 @@ class YoastCommentHacksAdmin {
 			if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
 				$min = '';
 			}
-			wp_enqueue_style( 'yoast-comment-hacks-admin-css', plugins_url( 'admin/assets/css/yoast-comment-hacks.css', YOAST_COMMENT_HACKS_FILE ), array(), YOAST_COMMENT_HACKS_VERSION );
-			wp_enqueue_script( 'yoast-comment-hacks-admin-js', plugins_url( 'admin/assets/js/yoast-comment-hacks.min.js', YOAST_COMMENT_HACKS_FILE ), array(), YOAST_COMMENT_HACKS_VERSION );
+
+			wp_enqueue_style(
+				'yoast-comment-hacks-admin-css',
+				plugins_url( 'admin/assets/css/yoast-comment-hacks.css', YOAST_COMMENT_HACKS_FILE ),
+				array(),
+				YOAST_COMMENT_HACKS_VERSION
+			);
+
+			wp_enqueue_script(
+				'yoast-comment-hacks-admin-js',
+				plugins_url( 'admin/assets/js/yoast-comment-hacks.min.js', YOAST_COMMENT_HACKS_FILE ),
+				array(),
+				YOAST_COMMENT_HACKS_VERSION,
+				true
+			);
 		}
 	}
 


### PR DESCRIPTION
By loading scripts in the footer of a page, the page rendering is not blocked by the script download.

Includes minor code layout reformatting for readability.

## Technical

* Added `grunt shell:phpcs` override. Travis failed when calling `vendor/squizlabs/php_codesniffer/scripts/phpcs` (defined in `@yoast/plugin-grunt-tasks`) but in this version of php_codesniffer it is located in `vendor/squizlabs/php_codesniffer/bin/phpcs`.

## Testing

Highly recommended!