### PR TITLE
QA: use strict comparisons

### DIFF
--- a/inc/class-comment-hacks.php
+++ b/inc/class-comment-hacks.php
@@ -84,7 +84,7 @@ class YoastCommentHacks {
 		// If no approved comments have been found, show the thank-you page.
 		if ( empty( $has_approved_comment ) ) {
 			// Only change $url when the page option is actually set and not zero.
-			if ( isset( $this->options['redirect_page'] ) && 0 != $this->options['redirect_page'] ) {
+			if ( isset( $this->options['redirect_page'] ) && 0 !== $this->options['redirect_page'] ) {
 				$url = get_permalink( $this->options['redirect_page'] );
 
 				/**


### PR DESCRIPTION
Based on `YoastCommentHacksAdmin::options_validate()`, the value of `redirect_page` should be an integer, so doing a strict, integer based comparison should work fine.

## Testing

Highly recommended!

---

NOTE: build failure is unrelated to this PR. See: https://travis-ci.org/Yoast/comment-hacks/jobs/546676738