### PR TITLE
CS: review of all include and require statements

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -238,7 +238,7 @@ class YoastCommentHacksAdmin {
 	public function config_page() {
 		$this->register_i18n_promo_class();
 
-		require_once 'views/config-page.php';
+		require_once YST_COMMENT_HACKS_PATH . 'admin/views/config-page.php';
 
 		// Show the content of the options array when debug is enabled.
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {

--- a/admin/class-comment-parent.php
+++ b/admin/class-comment-parent.php
@@ -27,7 +27,7 @@ class YoastCommentParent {
 	 * @param object $comment The comment object.
 	 */
 	public function comment_parent_box( $comment ) {
-		require_once 'views/comment-parent-box.php';
+		require_once YST_COMMENT_HACKS_PATH . 'admin/views/comment-parent-box.php';
 	}
 
 	/**

--- a/yoast-comment-hacks.php
+++ b/yoast-comment-hacks.php
@@ -45,8 +45,8 @@ if ( ! defined( 'YST_COMMENT_HACKS_PATH' ) ) {
 }
 
 /* ***************************** CLASS AUTOLOADING *************************** */
-if ( file_exists( YST_COMMENT_HACKS_PATH . '/vendor/autoload_52.php' ) ) {
-	require YST_COMMENT_HACKS_PATH . '/vendor/autoload_52.php';
+if ( file_exists( YST_COMMENT_HACKS_PATH . 'vendor/autoload_52.php' ) ) {
+	require YST_COMMENT_HACKS_PATH . 'vendor/autoload_52.php';
 }
 
 new YoastCommentHacks();


### PR DESCRIPTION
`include` and `require` are language constructs, not functions.

With that in mind there are a number of best practices surrounding them:
* There is no need to use parenthesis and not doing so will be, albeit marginally, faster.
* Always pass an absolute path for maximum portability. The `yoast-comment-hacks.php` file defines the `YST_COMMENT_HACKS_PATH` constant to be used for that (includes trailing slash), WP itself has `ABSPATH` (includes trailing slash).
* As all the relevant PATH constants already contain a trailing slash, there is no need for a slash at the start of the text string pointing to the exact file to be included.