### PR TITLE
Travis: minor clean up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,7 @@ before_install:
 install:
   - |
     if [[ "$CHECK" == "1" ]]; then
-      if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then phpenv local 5.6.13; fi
       composer install --no-interaction
-      if [[ $TRAVIS_PHP_VERSION == "5.2" ]]; then phpenv local --unset; fi
     fi
   - |
     if [[ "$CHECK" == "1" ]]; then


### PR DESCRIPTION
The `composer install` is run conditionally based on the `CHECK` ENV variable which is only set on a high PHP version (7.3), so no need to account for PHP 5.2 here.