### PR TITLE
CS: rename all classes to comply with the rules

### DIFF
--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -44,7 +44,7 @@ class Yoast_Comment_Admin {
 	 * Class constructor.
 	 */
 	public function __construct() {
-		$this->options = YoastCommentHacks::get_options();
+		$this->options = Yoast_Comment_Hacks::get_options();
 
 		// Hook into init for registration of the option and the language files.
 		add_action( 'admin_init', array( $this, 'init' ) );
@@ -69,8 +69,8 @@ class Yoast_Comment_Admin {
 	public function init() {
 		// Register our option array.
 		register_setting(
-			YoastCommentHacks::$option_name,
-			YoastCommentHacks::$option_name,
+			Yoast_Comment_Hacks::$option_name,
+			Yoast_Comment_Hacks::$option_name,
 			array(
 				$this,
 				'options_validate',
@@ -182,7 +182,7 @@ class Yoast_Comment_Admin {
 	 * @return array $input Validated input.
 	 */
 	public function options_validate( $input ) {
-		$defaults = YoastCommentHacks::get_defaults();
+		$defaults = Yoast_Comment_Hacks::get_defaults();
 
 		$input['mincomlength']  = (int) $input['mincomlength'];
 		$input['maxcomlength']  = (int) $input['maxcomlength'];

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -60,7 +60,7 @@ class Yoast_Comment_Admin {
 		add_action( 'post_comment_status_meta_box-options', array( $this, 'reroute_comment_emails_option' ) );
 		add_action( 'save_post', array( $this, 'save_reroute_comment_emails' ) );
 
-		new YoastCommentParent();
+		new Yoast_Comment_Parent();
 	}
 
 	/**

--- a/admin/class-admin.php
+++ b/admin/class-admin.php
@@ -6,9 +6,11 @@
  */
 
 /**
- * Class YoastCommentHacksAdmin.
+ * Class Yoast_Comment_Admin.
+ *
+ * @since 1.6.0 Class renamed from `YoastCommentHacksAdmin` to `Yoast_Comment_Admin`.
  */
-class YoastCommentHacksAdmin {
+class Yoast_Comment_Admin {
 
 	/**
 	 * Recipient key.

--- a/admin/class-comment-parent.php
+++ b/admin/class-comment-parent.php
@@ -6,11 +6,12 @@
  */
 
 /**
- * Class YoastCommentParent.
+ * Class Yoast_Comment_Parent.
  *
  * @since 1.3
+ * @since 1.6.0 Class renamed from `YoastCommentParent` to `Yoast_Comment_Parent`.
  */
-class YoastCommentParent {
+class Yoast_Comment_Parent {
 
 	/**
 	 * Class constructor.

--- a/admin/views/config-page.php
+++ b/admin/views/config-page.php
@@ -5,7 +5,7 @@
  * @package YoastCommentHacks\admin
  */
 
-$yoast_comment_option_name = YoastCommentHacks::$option_name;
+$yoast_comment_option_name = Yoast_Comment_Hacks::$option_name;
 ?>
 	<div class="wrap">
 		<h2><?php esc_html_e( 'Yoast Comment Hacks', 'yoast-comment-hacks' ); ?></h2>

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
 	"autoload": {
 		"classmap": [
 			"admin/",
+			"deprecated/",
 			"inc/"
 		]
 	},

--- a/deprecated/deprecated-classes.php
+++ b/deprecated/deprecated-classes.php
@@ -12,6 +12,7 @@
  *
  * @phpcs:disable Yoast.Files.FileName.InvalidClassFileName
  * @phpcs:disable Yoast.Commenting.CodeCoverageIgnoreDeprecated
+ * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
  */
 
 _deprecated_file( basename( __FILE__ ), 'Yoast Comment Hacks 1.6.0' );
@@ -32,6 +33,25 @@ class YoastCommentHacksAdmin extends Yoast_Comment_Admin {
 	 */
 	public function __construct() {
 		_deprecated_function( __METHOD__, 'Yoast Comment Hacks 1.6.0', 'Yoast_Comment_Admin' );
+		parent::__construct();
+	}
+}
+
+/**
+ * Class YoastCommentParent.
+ *
+ * @since      1.3
+ * @deprecated 1.6.0 Use {@see Yoast_Comment_Parent} instead.
+ */
+class YoastCommentParent extends Yoast_Comment_Parent {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @deprecated 1.6.0 Use {@see Yoast_Comment_Parent} instead.
+	 */
+	public function __construct() {
+		_deprecated_function( __METHOD__, 'Yoast Comment Hacks 1.6.0', 'Yoast_Comment_Parent' );
 		parent::__construct();
 	}
 }

--- a/deprecated/deprecated-classes.php
+++ b/deprecated/deprecated-classes.php
@@ -93,3 +93,22 @@ class YoastCommentHacksEmailLinks extends Yoast_Comment_Email_Links {
 		parent::__construct();
 	}
 }
+
+/**
+ * Class YoastCommentFormHacks.
+ *
+ * @since      1.3
+ * @deprecated 1.6.0 Use {@see Yoast_Comment_Forms} instead.
+ */
+class YoastCommentFormHacks extends Yoast_Comment_Forms {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @deprecated 1.6.0 Use {@see Yoast_Comment_Forms} instead.
+	 */
+	public function __construct() {
+		_deprecated_function( __METHOD__, 'Yoast Comment Hacks 1.6.0', 'Yoast_Comment_Forms' );
+		parent::__construct();
+	}
+}

--- a/deprecated/deprecated-classes.php
+++ b/deprecated/deprecated-classes.php
@@ -131,3 +131,22 @@ class YoastCommentHacks extends Yoast_Comment_Hacks {
 		parent::__construct();
 	}
 }
+
+/**
+ * Class YoastCommentLength.
+ *
+ * @since      1.3
+ * @deprecated 1.6.0 Use {@see Yoast_Comment_Length} instead.
+ */
+class YoastCommentLength extends Yoast_Comment_Length {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @deprecated 1.6.0 Use {@see Yoast_Comment_Length} instead.
+	 */
+	public function __construct() {
+		_deprecated_function( __METHOD__, 'Yoast Comment Hacks 1.6.0', 'Yoast_Comment_Length' );
+		parent::__construct();
+	}
+}

--- a/deprecated/deprecated-classes.php
+++ b/deprecated/deprecated-classes.php
@@ -112,3 +112,22 @@ class YoastCommentFormHacks extends Yoast_Comment_Forms {
 		parent::__construct();
 	}
 }
+
+/**
+ * Class YoastCommentHacks.
+ *
+ * @since      1.0
+ * @deprecated 1.6.0 Use {@see Yoast_Comment_Hacks} instead.
+ */
+class YoastCommentHacks extends Yoast_Comment_Hacks {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @deprecated 1.6.0 Use {@see Yoast_Comment_Hacks} instead.
+	 */
+	public function __construct() {
+		_deprecated_function( __METHOD__, 'Yoast Comment Hacks 1.6.0', 'Yoast_Comment_Hacks' );
+		parent::__construct();
+	}
+}

--- a/deprecated/deprecated-classes.php
+++ b/deprecated/deprecated-classes.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Graceful deprecation of various classes which were renamed.
+ *
+ * @package YoastCommentHacks
+ *
+ * @since      1.6.0
+ * @deprecated 1.6.0
+ *
+ * As this file is just (temporarily) put in place to warn extending plugins
+ * about the class name changes, it is exempt from select CS standards.
+ *
+ * @phpcs:disable Yoast.Files.FileName.InvalidClassFileName
+ * @phpcs:disable Yoast.Commenting.CodeCoverageIgnoreDeprecated
+ */
+
+_deprecated_file( basename( __FILE__ ), 'Yoast Comment Hacks 1.6.0' );
+
+/* ******************* /admin/ ******************* */
+
+/**
+ * Class YoastCommentHacksAdmin.
+ *
+ * @deprecated 1.6.0 Use {@see Yoast_Comment_Admin} instead.
+ */
+class YoastCommentHacksAdmin extends Yoast_Comment_Admin {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @deprecated 1.6.0 Use {@see Yoast_Comment_Admin} instead.
+	 */
+	public function __construct() {
+		_deprecated_function( __METHOD__, 'Yoast Comment Hacks 1.6.0', 'Yoast_Comment_Admin' );
+		parent::__construct();
+	}
+}

--- a/deprecated/deprecated-classes.php
+++ b/deprecated/deprecated-classes.php
@@ -150,3 +150,22 @@ class YoastCommentLength extends Yoast_Comment_Length {
 		parent::__construct();
 	}
 }
+
+/**
+ * Class YoastCommentNotifications.
+ *
+ * @since      1.1
+ * @deprecated 1.6.0 Use {@see Yoast_Comment_Notifications} instead.
+ */
+class YoastCommentNotifications extends Yoast_Comment_Notifications {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @deprecated 1.6.0 Use {@see Yoast_Comment_Notifications} instead.
+	 */
+	public function __construct() {
+		_deprecated_function( __METHOD__, 'Yoast Comment Hacks 1.6.0', 'Yoast_Comment_Notifications' );
+		parent::__construct();
+	}
+}

--- a/deprecated/deprecated-classes.php
+++ b/deprecated/deprecated-classes.php
@@ -55,3 +55,23 @@ class YoastCommentParent extends Yoast_Comment_Parent {
 		parent::__construct();
 	}
 }
+
+/* ******************* /inc/ ******************* */
+
+/**
+ * Class YoastCleanEmails.
+ *
+ * @deprecated 1.6.0 Use {@see Yoast_Comment_Clean_Emails} instead.
+ */
+class YoastCleanEmails extends Yoast_Comment_Clean_Emails {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @deprecated 1.6.0 Use {@see Yoast_Comment_Clean_Emails} instead.
+	 */
+	public function __construct() {
+		_deprecated_function( __METHOD__, 'Yoast Comment Hacks 1.6.0', 'Yoast_Comment_Clean_Emails' );
+		parent::__construct();
+	}
+}

--- a/deprecated/deprecated-classes.php
+++ b/deprecated/deprecated-classes.php
@@ -75,3 +75,21 @@ class YoastCleanEmails extends Yoast_Comment_Clean_Emails {
 		parent::__construct();
 	}
 }
+
+/**
+ * Class YoastCommentHacksEmailLinks.
+ *
+ * @deprecated 1.6.0 Use {@see Yoast_Comment_Email_Links} instead.
+ */
+class YoastCommentHacksEmailLinks extends Yoast_Comment_Email_Links {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @deprecated 1.6.0 Use {@see Yoast_Comment_Email_Links} instead.
+	 */
+	public function __construct() {
+		_deprecated_function( __METHOD__, 'Yoast Comment Hacks 1.6.0', 'Yoast_Comment_Email_Links' );
+		parent::__construct();
+	}
+}

--- a/inc/class-clean-emails.php
+++ b/inc/class-clean-emails.php
@@ -6,9 +6,11 @@
  */
 
 /**
- * Class YoastCleanEmails.
+ * Class Yoast_Comment_Clean_Emails.
+ *
+ * @since 1.6.0 Class renamed from `YoastCleanEmails` to `Yoast_Comment_Clean_Emails`.
  */
-class YoastCleanEmails {
+class Yoast_Comment_Clean_Emails {
 
 	/**
 	 * Holds the current comment's ID.

--- a/inc/class-comment-email-links.php
+++ b/inc/class-comment-email-links.php
@@ -23,7 +23,7 @@ class Yoast_Comment_Email_Links {
 	 * Class constructor.
 	 */
 	public function __construct() {
-		$this->options = YoastCommentHacks::get_options();
+		$this->options = Yoast_Comment_Hacks::get_options();
 
 		add_action( 'init', array( $this, 'init' ) );
 	}

--- a/inc/class-comment-email-links.php
+++ b/inc/class-comment-email-links.php
@@ -6,9 +6,11 @@
  */
 
 /**
- * Class YoastCommentHacksEmailLinks.
+ * Class Yoast_Comment_Email_Links.
+ *
+ * @since 1.6.0 Class renamed from `YoastCommentHacksEmailLinks` to `Yoast_Comment_Email_Links`.
  */
-class YoastCommentHacksEmailLinks {
+class Yoast_Comment_Email_Links {
 
 	/**
 	 * Holds the plugins options.

--- a/inc/class-comment-form-hacks.php
+++ b/inc/class-comment-form-hacks.php
@@ -24,7 +24,7 @@ class Yoast_Comment_Forms {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->options = YoastCommentHacks::get_options();
+		$this->options = Yoast_Comment_Hacks::get_options();
 
 		add_filter( 'comment_form_defaults', array( $this, 'filter_defaults' ) );
 	}

--- a/inc/class-comment-form-hacks.php
+++ b/inc/class-comment-form-hacks.php
@@ -6,11 +6,12 @@
  */
 
 /**
- * Class YoastCommentFormHacks.
+ * Class Yoast_Comment_Forms.
  *
  * @since 1.3
+ * @since 1.6.0 Class renamed from `YoastCommentFormHacks` to `Yoast_Comment_Forms`.
  */
-class YoastCommentFormHacks {
+class Yoast_Comment_Forms {
 
 	/**
 	 * Holds the plugins options.
@@ -20,7 +21,7 @@ class YoastCommentFormHacks {
 	private $options = array();
 
 	/**
-	 * YoastCommentFormHacks constructor.
+	 * Constructor.
 	 */
 	public function __construct() {
 		$this->options = YoastCommentHacks::get_options();

--- a/inc/class-comment-hacks.php
+++ b/inc/class-comment-hacks.php
@@ -48,7 +48,7 @@ class YoastCommentHacks {
 		}
 
 		new YoastCommentNotifications();
-		new YoastCommentHacksEmailLinks();
+		new Yoast_Comment_Email_Links();
 		new YoastCommentFormHacks();
 		new YoastCommentLength();
 	}

--- a/inc/class-comment-hacks.php
+++ b/inc/class-comment-hacks.php
@@ -49,7 +49,7 @@ class YoastCommentHacks {
 
 		new YoastCommentNotifications();
 		new Yoast_Comment_Email_Links();
-		new YoastCommentFormHacks();
+		new Yoast_Comment_Forms();
 		new YoastCommentLength();
 	}
 

--- a/inc/class-comment-hacks.php
+++ b/inc/class-comment-hacks.php
@@ -51,7 +51,7 @@ class Yoast_Comment_Hacks {
 		new YoastCommentNotifications();
 		new Yoast_Comment_Email_Links();
 		new Yoast_Comment_Forms();
-		new YoastCommentLength();
+		new Yoast_Comment_Length();
 	}
 
 	/**

--- a/inc/class-comment-hacks.php
+++ b/inc/class-comment-hacks.php
@@ -40,7 +40,7 @@ class YoastCommentHacks {
 		add_filter( 'comment_post_redirect', array( $this, 'comment_redirect' ), 10, 2 );
 
 		if ( $this->options['clean_emails'] ) {
-			new YoastCleanEmails();
+			new Yoast_Comment_Clean_Emails();
 		}
 
 		if ( is_admin() ) {

--- a/inc/class-comment-hacks.php
+++ b/inc/class-comment-hacks.php
@@ -44,7 +44,7 @@ class YoastCommentHacks {
 		}
 
 		if ( is_admin() ) {
-			new YoastCommentHacksAdmin();
+			new Yoast_Comment_Admin();
 		}
 
 		new YoastCommentNotifications();

--- a/inc/class-comment-hacks.php
+++ b/inc/class-comment-hacks.php
@@ -6,11 +6,12 @@
  */
 
 /**
- * Class YoastCommentHacks.
+ * Class Yoast_Comment_Hacks.
  *
  * @since 1.0
+ * @since 1.6.0 Class renamed from `YoastCommentHacks` to `Yoast_Comment_Hacks`.
  */
-class YoastCommentHacks {
+class Yoast_Comment_Hacks {
 
 	/**
 	 * Holds the plugins option name.

--- a/inc/class-comment-hacks.php
+++ b/inc/class-comment-hacks.php
@@ -48,7 +48,7 @@ class Yoast_Comment_Hacks {
 			new Yoast_Comment_Admin();
 		}
 
-		new YoastCommentNotifications();
+		new Yoast_Comment_Notifications();
 		new Yoast_Comment_Email_Links();
 		new Yoast_Comment_Forms();
 		new Yoast_Comment_Length();

--- a/inc/class-comment-length.php
+++ b/inc/class-comment-length.php
@@ -6,11 +6,12 @@
  */
 
 /**
- * Class YoastCommentLength.
+ * Class Yoast_Comment_Length.
  *
  * @since 1.3
+ * @since 1.6.0 Class renamed from `YoastCommentLength` to `Yoast_Comment_Length`.
  */
-class YoastCommentLength {
+class Yoast_Comment_Length {
 
 	/**
 	 * Holds the plugins options.
@@ -20,7 +21,7 @@ class YoastCommentLength {
 	private $options = array();
 
 	/**
-	 * YoastCommentLength constructor.
+	 * Constructor.
 	 */
 	public function __construct() {
 		$this->options = Yoast_Comment_Hacks::get_options();

--- a/inc/class-comment-length.php
+++ b/inc/class-comment-length.php
@@ -23,7 +23,7 @@ class YoastCommentLength {
 	 * YoastCommentLength constructor.
 	 */
 	public function __construct() {
-		$this->options = YoastCommentHacks::get_options();
+		$this->options = Yoast_Comment_Hacks::get_options();
 
 		// Process the comment and check it for length.
 		add_filter( 'preprocess_comment', array( $this, 'check_comment_length' ) );

--- a/inc/class-comment-notifications.php
+++ b/inc/class-comment-notifications.php
@@ -6,14 +6,15 @@
  */
 
 /**
- * Class YoastCommentNotifications.
+ * Class Yoast_Comment_Notifications.
  *
  * @since 1.1
+ * @since 1.6.0 Class renamed from `YoastCommentNotifications` to `Yoast_Comment_Notifications`.
  */
-class YoastCommentNotifications {
+class Yoast_Comment_Notifications {
 
 	/**
-	 * YoastCommentNotifications constructor.
+	 * Constructor.
 	 */
 	public function __construct() {
 		add_filter( 'comment_notification_recipients', array( $this, 'filter_notification_recipients' ), 10, 2 );

--- a/yoast-comment-hacks.php
+++ b/yoast-comment-hacks.php
@@ -49,4 +49,4 @@ if ( file_exists( YST_COMMENT_HACKS_PATH . 'vendor/autoload_52.php' ) ) {
 	require YST_COMMENT_HACKS_PATH . 'vendor/autoload_52.php';
 }
 
-new YoastCommentHacks();
+new Yoast_Comment_Hacks();


### PR DESCRIPTION
## Description

Compliance with the YoastCS/WPCS class name rules, including the prefixing rules.

Includes:
* Adjusting existing references to the old class names within the plugin.
* Putting a fallback class in place for each class with the old class name extending the new class name to not break BC.
    This allows for throwing deprecation notices if there would happen to be another plugin which extends the (old) class.

As discussed with @herregroen on Slack, all the "fallback classes" have been put into one (new) file `deprecated/deprecated-classes.php`.

### Notes
1. I've removed the `Hacks` from the class name for `Admin`, `Email_Links` and `Forms`.
2. I've added `Comment` to the class name for `Clean_Emails` to comply with the plugin prefixing rules.

### For comparison:

Folder | Old Class Name | New Class Name
-- | -- | --
admin | YoastComment**Hacks**Admin | Yoast_Comment_Admin
admin | YoastCommentParent | Yoast_Comment_Parent
inc | YoastCleanEmails | Yoast_**Comment**_Clean_Emails
inc | YoastComment**Hacks**EmailLinks | Yoast_Comment_Email_Links
inc | YoastCommentForm**Hacks** | Yoast_Comment_Forms
inc | YoastCommentHacks | Yoast_Comment_Hacks
inc | YoastCommentLength | Yoast_Comment_Length
inc | YoastCommentNotifications | Yoast_Comment_Notifications

## Code Review

This PR will be easiest to review by inspecting each commit individually.

## Testing

Testing this change is highly recommended!

To test it:
* Make sure you have an install with this plugin activated and `WP_DEBUG` = `true`. 
* Switch to this branch and run `composer dump-autoload`.
* Open any page on the website. Most potential problems should be visible straight away with a fatal error for a missing class.
* Check on a blog page with a comment form.
* Check the Comment Hacks admin page.

If all looks as expected and there have been no error notices or white screens, we're good.


