### PR TITLE
Stop explicit support for PHP < 5.6 /  WP < 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 dist: trusty
-sudo: false
 
 branches:
   only:
@@ -14,13 +13,15 @@ jobs:
   include:
     - php: 7.3
       env: PHPLINT=1 CHECK=1 TRAVIS_NODE_VERSION=node
-    - php: 5.3
-      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
-      dist: precise
-    - php: 5.2
+    - php: 5.6
       env: PHPLINT=1
-      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
-      dist: precise
+    - php: "7.4snapshot"
+      env: PHPLINT=1
+    - php: "nightly"
+      env: PHPLINT=1
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: "nightly"
 
 cache:
   yarn: true
@@ -78,4 +79,4 @@ script:
     fi
   # Validate the composer.json file.
   # @link https://getcomposer.org/doc/03-cli.md#validate
-  - if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi
+  - if [[ $TRAVIS_PHP_VERSION == "5.6" || $TRAVIS_PHP_VERSION == "7.3" ]]; then composer validate --no-check-all; fi

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"keywords": [
 		"comments",
 		"spam",
-        "emails"
+		"emails"
 	],
 	"homepage": "https://yoast.com/wordpress/plugins/comment-hacks/",
 	"license": "GPL-2.0-or-later",
@@ -23,9 +23,9 @@
 		"source": "https://github.com/Yoast/comment-hacks"
 	},
 	"require": {
+		"php": ">=5.6",
 		"composer/installers": "~1.0",
-		"yoast/i18n-module": "^3.1.1",
-		"xrstf/composer-php52": "^1.0.20"
+		"yoast/i18n-module": "^3.1.1"
 	},
 	"require-dev": {
 		"yoast/yoastcs": "^1.2.1"
@@ -42,15 +42,6 @@
 		"config-yoastcs": [
 			"\"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs,../../../vendor/yoast/yoastcs",
 			"\"vendor/bin/phpcs\" --config-set default_standard Yoast"
-		],
-		"post-install-cmd": [
-			"xrstf\\Composer52\\Generator::onPostInstallCmd"
-		],
-		"post-update-cmd": [
-			"xrstf\\Composer52\\Generator::onPostInstallCmd"
-		],
-		"post-autoload-dump": [
-			"xrstf\\Composer52\\Generator::onPostInstallCmd"
 		]
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc70c63937ab4fb4bd4085ba8e39e086",
+    "content-hash": "174e27822e205704958f97976d05b41d",
     "packages": [
         {
             "name": "composer/installers",
@@ -112,37 +112,6 @@
                 "zikula"
             ],
             "time": "2016-08-13T20:53:52+00:00"
-        },
-        {
-            "name": "xrstf/composer-php52",
-            "version": "v1.0.20",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer-php52/composer-php52.git",
-                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer-php52/composer-php52/zipball/bd41459d5e27df8d33057842b32377c39e97a5a8",
-                "reference": "bd41459d5e27df8d33057842b32377c39e97a5a8",
-                "shasum": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-default": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "xrstf\\Composer52": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "time": "2016-04-16T21:52:24+00:00"
         },
         {
             "name": "yoast/i18n-module",
@@ -938,12 +907,12 @@
             "version": "1.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
                 "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress-Coding-Standards/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
                 "reference": "f328bcafd97377e8e5e5d7b244d5ddbf301a3a5c",
                 "shasum": ""
             },
@@ -1029,6 +998,8 @@
     "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.6"
+    },
     "platform-dev": []
 }

--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,7 @@ Tested up to: 5.3
 Stable tag: 1.6
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Requires PHP: 5.6.20
 
 Make comments management easier by applying some of the simple hacks the Yoast team uses.
 

--- a/yoast-comment-hacks.php
+++ b/yoast-comment-hacks.php
@@ -45,8 +45,8 @@ if ( ! defined( 'YST_COMMENT_HACKS_PATH' ) ) {
 }
 
 /* ***************************** CLASS AUTOLOADING *************************** */
-if ( file_exists( YST_COMMENT_HACKS_PATH . 'vendor/autoload_52.php' ) ) {
-	require YST_COMMENT_HACKS_PATH . 'vendor/autoload_52.php';
+if ( file_exists( YST_COMMENT_HACKS_PATH . 'vendor/autoload.php' ) ) {
+	require YST_COMMENT_HACKS_PATH . 'vendor/autoload.php';
 }
 
 new YoastCommentHacks();


### PR DESCRIPTION
Includes:
* Adjusting the `Requires...` info in the `readme.txt` file.
* Removing builds against PHP < 5.6.
* Adding a build against PHP 7.4 and `nightly` (PHP 8).
    The `nightly` build is allowed to fail for now.
* Removing the `xrstf/composer-php52` dependency and references to the  `vendor/autoload_52.php` file.

As the Comment Hacks plugin does not contain unit tests, these changes can already be made and made in one go.

Also:
* Travis hasn't supported `sudo` for quite a while now, so removing it.

Note: the build failure is unrelated to this PR.

Related to https://github.com/Yoast/wordpress-seo/issues/13758