### PR TITLE
PHPCS: Update to YoastCS 2.0.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -75,7 +75,6 @@
 		<exclude-pattern>*/deprecated/deprecated-classes\.php$</exclude-pattern>
 	</rule>
 
-				<element value="yoast_ch"/>
 
 	<!--
 	#############################################################################

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -33,7 +33,15 @@
 	#############################################################################
 	-->
 
-	<rule ref="Yoast"/>
+	<rule ref="Yoast">
+		<properties>
+			<!-- Provide the plugin specific prefix for use with namespace and hook names. -->
+			<property name="prefixes" type="array">
+				<element value="Yoast\WP\Comment"/>
+				<element value="yoast_comment"/>
+			</property>
+		</properties>
+	</rule>
 
 
 	<!--
@@ -54,12 +62,12 @@
 	<rule ref="Yoast.Files.FileName">
 		<properties>
 			<!-- Don't trigger on the main file as renaming it would deactivate the plugin. -->
-			<property name="exclude" type="array">
+			<property name="excluded_files_strict_check" type="array">
 				<element value="yoast-comment-hacks.php"/>
 			</property>
 
 			<!-- Remove the following prefixes from the names of object structures. -->
-			<property name="prefixes" type="array">
+			<property name="oo_prefixes" type="array">
 				<element value="yoast_comment"/>
 			</property>
 		</properties>
@@ -67,21 +75,17 @@
 		<exclude-pattern>*/deprecated/deprecated-classes\.php$</exclude-pattern>
 	</rule>
 
-	<!-- Verify that everything in the global namespace is prefixed with a plugin specific prefix. -->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
-		<properties>
-			<!-- Provide the prefixes to look for. -->
-			<property name="prefixes" type="array">
-				<!-- Temporarily allowed until the prefixes are fixed. -->
 				<element value="yoast_ch"/>
-				<element value="yst_comment"/>
 
-				<!-- These are the new prefixes which all code should comply with in the future. -->
-				<element value="yoast_comment"/>
-				<element value="Yoast\WP\Comment"/>
-			</property>
-		</properties>
+	<!--
+	#############################################################################
+	SELECTIVE EXCLUSIONS
+	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
+	#############################################################################
+	-->
 
+	<!-- Valid: These classes were deprecated to comply with the prefixing rules. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<exclude-pattern>*/deprecated/*\.php$</exclude-pattern>
 	</rule>
 
@@ -92,6 +96,15 @@
 	Adjustments which should be removed once the associated issue has been resolved.
 	#############################################################################
 	-->
+
+	<!-- Until all prefixes are fixed, some exceptions are allowed to the PrefixAllGlobals sniff. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" extend="true">
+				<element value="yst_comment"/>
+			</property>
+		</properties>
+	</rule>
 
 	<!-- Direct database queries need careful review.
 		 Ticket: https://github.com/Yoast/comment-hacks/issues/50

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -136,17 +136,33 @@ class Admin {
 		 * This filter allows filtering which roles should be shown in the dropdown for notifications.
 		 * Defaults to contributor and up.
 		 *
+		 * @deprecated 1.6.0. Use the {@see 'Yoast\WP\Comment\notification_roles'} filter instead.
+		 *
 		 * @param array $roles Array with user roles.
 		 */
-		$roles = \apply_filters(
+		$roles = \apply_filters_deprecated(
 			'yoast_comment_hacks_notification_roles',
 			array(
-				'author',
-				'contributor',
-				'editor',
-				'administrator',
-			)
+				array(
+					'author',
+					'contributor',
+					'editor',
+					'administrator',
+				),
+			),
+			'Yoast Comment 1.6.0',
+			'Yoast\WP\Comment\notification_roles'
 		);
+
+		/**
+		 * This filter allows filtering which roles should be shown in the dropdown for notifications.
+		 * Defaults to contributor and up.
+		 *
+		 * @since 1.6.0
+		 *
+		 * @param array $roles Array with user roles.
+		 */
+		$roles = \apply_filters( 'Yoast\WP\Comment\notification_roles', $roles );
 
 		\wp_dropdown_users(
 			array(

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -118,7 +118,7 @@ class Admin {
 			array(
 				'textdomain'  => 'yoast-comment-hacks',
 				'plugin_name' => 'Yoast Comment Hacks',
-				'hook'        => 'yoast_ch_admin_footer',
+				'hook'        => 'Yoast\WP\Comment\admin_footer',
 			)
 		);
 	}

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -32,7 +32,7 @@ class Admin {
 	 *
 	 * @var array
 	 */
-	private $options = array();
+	private $options = [];
 
 	/**
 	 * The absolute minimum comment length when this plugin is enabled.
@@ -48,18 +48,18 @@ class Admin {
 		$this->options = Hacks::get_options();
 
 		// Hook into init for registration of the option and the language files.
-		\add_action( 'admin_init', array( $this, 'init' ) );
+		\add_action( 'admin_init', [ $this, 'init' ] );
 
 		// Register the settings page.
-		\add_action( 'admin_menu', array( $this, 'add_config_page' ) );
-		\add_action( 'admin_enqueue_scripts', array( $this, 'enqueue' ) );
+		\add_action( 'admin_menu', [ $this, 'add_config_page' ] );
+		\add_action( 'admin_enqueue_scripts', [ $this, 'enqueue' ] );
 
 		// Register a link to the settings page on the plugins overview page.
-		\add_filter( 'plugin_action_links', array( $this, 'filter_plugin_actions' ), 10, 2 );
+		\add_filter( 'plugin_action_links', [ $this, 'filter_plugin_actions' ], 10, 2 );
 
 		// Filter the comment notification recipients.
-		\add_action( 'post_comment_status_meta_box-options', array( $this, 'reroute_comment_emails_option' ) );
-		\add_action( 'save_post', array( $this, 'save_reroute_comment_emails' ) );
+		\add_action( 'post_comment_status_meta_box-options', [ $this, 'reroute_comment_emails_option' ] );
+		\add_action( 'save_post', [ $this, 'save_reroute_comment_emails' ] );
 
 		new Comment_Parent();
 	}
@@ -72,10 +72,10 @@ class Admin {
 		\register_setting(
 			Hacks::$option_name,
 			Hacks::$option_name,
-			array(
+			[
 				$this,
 				'options_validate',
-			)
+			]
 		);
 	}
 
@@ -94,14 +94,14 @@ class Admin {
 			\wp_enqueue_style(
 				'yoast-comment-hacks-admin-css',
 				\plugins_url( 'admin/assets/css/yoast-comment-hacks.css', \YOAST_COMMENT_HACKS_FILE ),
-				array(),
+				[],
 				\YOAST_COMMENT_HACKS_VERSION
 			);
 
 			\wp_enqueue_script(
 				'yoast-comment-hacks-admin-js',
 				\plugins_url( 'admin/assets/js/yoast-comment-hacks.min.js', \YOAST_COMMENT_HACKS_FILE ),
-				array(),
+				[],
 				\YOAST_COMMENT_HACKS_VERSION,
 				true
 			);
@@ -115,11 +115,11 @@ class Admin {
 	 */
 	public function register_i18n_promo_class() {
 		new Yoast_I18n_WordPressOrg_v3(
-			array(
+			[
 				'textdomain'  => 'yoast-comment-hacks',
 				'plugin_name' => 'Yoast Comment Hacks',
 				'hook'        => 'Yoast\WP\Comment\admin_footer',
-			)
+			]
 		);
 	}
 
@@ -142,14 +142,14 @@ class Admin {
 		 */
 		$roles = \apply_filters_deprecated(
 			'yoast_comment_hacks_notification_roles',
-			array(
-				array(
+			[
+				[
 					'author',
 					'contributor',
 					'editor',
 					'administrator',
-				),
-			),
+				],
+			],
 			'Yoast Comment 1.6.0',
 			'Yoast\WP\Comment\notification_roles'
 		);
@@ -165,14 +165,14 @@ class Admin {
 		$roles = \apply_filters( 'Yoast\WP\Comment\notification_roles', $roles );
 
 		\wp_dropdown_users(
-			array(
+			[
 				'selected'          => \get_post_meta( $post_id, self::NOTIFICATION_RECIPIENT_KEY, true ),
 				'show_option_none'  => 'Post author',
 				'name'              => 'comment_notification_recipient',
 				'id'                => 'comment_notification_recipient',
 				'role__in'          => $roles,
 				'option_none_value' => 0,
-			)
+			]
 		);
 	}
 
@@ -207,7 +207,7 @@ class Admin {
 		$input['clean_emails']  = isset( $input['clean_emails'] ) ? 1 : 0;
 		$input['version']       = \YOAST_COMMENT_HACKS_VERSION;
 
-		foreach ( array( 'email_subject', 'email_body', 'mass_email_body' ) as $key ) {
+		foreach ( [ 'email_subject', 'email_body', 'mass_email_body' ] as $key ) {
 			if ( $input[ $key ] === '' ) {
 				$input[ $key ] = $defaults[ $key ];
 			}
@@ -231,10 +231,10 @@ class Admin {
 			\__( 'Comment Hacks', 'yoast-comment-hacks' ),
 			'manage_options',
 			$this->hook,
-			array(
+			[
 				$this,
 				'config_page',
-			)
+			]
 		);
 	}
 

--- a/admin/comment-parent.php
+++ b/admin/comment-parent.php
@@ -15,8 +15,8 @@ class Comment_Parent {
 	 */
 	public function __construct() {
 		// The hooks for editing and saving the comment parent.
-		\add_action( 'admin_menu', array( $this, 'load_comment_parent_box' ) );
-		\add_action( 'edit_comment', array( $this, 'update_comment_parent' ) );
+		\add_action( 'admin_menu', [ $this, 'load_comment_parent_box' ] );
+		\add_action( 'edit_comment', [ $this, 'update_comment_parent' ] );
 	}
 
 	/**
@@ -36,10 +36,10 @@ class Comment_Parent {
 			\add_meta_box(
 				'comment_parent',
 				'Comment Parent',
-				array(
+				[
 					$this,
 					'comment_parent_box',
-				),
+				],
 				'comment',
 				'normal'
 			);

--- a/admin/views/config-page.php
+++ b/admin/views/config-page.php
@@ -187,5 +187,15 @@ $yoast_comment_option_name = Hacks::$option_name;
 /**
  * Action hook to allow other plugins to add additional information to the
  * Yoast Comment Hacks admin page.
+ *
+ * @deprecated 1.6.0. Use the {@see 'Yoast\WP\Comment\admin_footer'} action instead.
  */
-do_action( 'yoast_ch_admin_footer' );
+do_action_deprecated( 'yoast_ch_admin_footer', array(), 'Yoast Comment 1.6.0', 'Yoast\WP\Comment\admin_footer' );
+
+/**
+ * Action hook to allow other plugins to add additional information to the
+ * Yoast Comment Hacks admin page.
+ *
+ * @since 1.6.0
+ */
+do_action( 'Yoast\WP\Comment\admin_footer' );

--- a/admin/views/config-page.php
+++ b/admin/views/config-page.php
@@ -143,7 +143,7 @@ $yoast_comment_option_name = Hacks::$option_name;
 						<?php
 							// A dropdown of all pages in the current WP install.
 							wp_dropdown_pages(
-								array(
+								[
 									'depth'             => 0,
 									'id'                => 'redirect_page',
 									// phpcs:ignore WordPress.Security.EscapeOutput -- This is a hard-coded string, just passed around as a variable.
@@ -151,7 +151,7 @@ $yoast_comment_option_name = Hacks::$option_name;
 									'option_none_value' => 0,
 									'selected'          => ( isset( $this->options['redirect_page'] ) ? (int) $this->options['redirect_page'] : 0 ),
 									'show_option_none'  => esc_html__( 'Don\'t redirect first time commenters', 'yoast-comment-hacks' ),
-								)
+								]
 							);
 
 							if ( isset( $this->options['redirect_page'] ) && $this->options['redirect_page'] !== 0 ) {
@@ -190,7 +190,7 @@ $yoast_comment_option_name = Hacks::$option_name;
  *
  * @deprecated 1.6.0. Use the {@see 'Yoast\WP\Comment\admin_footer'} action instead.
  */
-do_action_deprecated( 'yoast_ch_admin_footer', array(), 'Yoast Comment 1.6.0', 'Yoast\WP\Comment\admin_footer' );
+do_action_deprecated( 'yoast_ch_admin_footer', [], 'Yoast Comment 1.6.0', 'Yoast\WP\Comment\admin_footer' );
 
 /**
  * Action hook to allow other plugins to add additional information to the

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
 		"yoast/i18n-module": "^3.1.1"
 	},
 	"require-dev": {
-		"yoast/yoastcs": "^1.3.0"
+		"yoast/yoastcs": "^2.0.0"
 	},
 	"minimum-stability": "dev",
 	"prefer-stable": true,
@@ -45,7 +45,7 @@
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
 		],
 		"check-cs": [
-			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --runtime-set testVersion 5.6-"
+			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
 		],
 		"fix-cs": [
 			"@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "982d98a89c5ff3b3da1473a21a0b92a3",
+    "content-hash": "41394b87eb8771398bfb0a6ac639da49",
     "packages": [
         {
             "name": "composer/installers",
@@ -484,26 +484,28 @@
         },
         {
             "name": "yoast/yoastcs",
-            "version": "1.3.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/yoastcs.git",
-                "reference": "f2e02a9d743fb1f7d9a40dbe38c64333790ffcca"
+                "reference": "2f445bea2b94cfe352e3d5c11c1fc7071ca5545a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/f2e02a9d743fb1f7d9a40dbe38c64333790ffcca",
-                "reference": "f2e02a9d743fb1f7d9a40dbe38c64333790ffcca",
+                "url": "https://api.github.com/repos/Yoast/yoastcs/zipball/2f445bea2b94cfe352e3d5c11c1fc7071ca5545a",
+                "reference": "2f445bea2b94cfe352e3d5c11c1fc7071ca5545a",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
                 "php": ">=5.4",
-                "phpcompatibility/phpcompatibility-wp": "^2.0.0",
-                "squizlabs/php_codesniffer": "^3.4.2",
-                "wp-coding-standards/wpcs": "^2.1.1"
+                "phpcompatibility/phpcompatibility-wp": "^2.1.0",
+                "squizlabs/php_codesniffer": "^3.5.0",
+                "wp-coding-standards/wpcs": "^2.2.0"
             },
             "require-dev": {
+                "jakub-onderka/php-console-highlighter": "^0.4",
+                "jakub-onderka/php-parallel-lint": "^1.0",
                 "phpcompatibility/php-compatibility": "^9.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "roave/security-advisories": "dev-master"
@@ -528,7 +530,7 @@
                 "wordpress",
                 "yoast"
             ],
-            "time": "2019-07-31T12:06:40+00:00"
+            "time": "2019-12-17T07:40:59+00:00"
         }
     ],
     "aliases": [],

--- a/inc/clean-emails.php
+++ b/inc/clean-emails.php
@@ -41,11 +41,11 @@ class Clean_Emails {
 	 * Class constructor.
 	 */
 	public function __construct() {
-		\add_filter( 'comment_notification_text', array( $this, 'comment_notification_text' ), 10, 2 );
-		\add_filter( 'comment_moderation_text', array( $this, 'comment_moderation_text' ), 10, 2 );
+		\add_filter( 'comment_notification_text', [ $this, 'comment_notification_text' ], 10, 2 );
+		\add_filter( 'comment_moderation_text', [ $this, 'comment_moderation_text' ], 10, 2 );
 
-		\add_filter( 'comment_notification_headers', array( $this, 'comment_email_headers' ) );
-		\add_filter( 'comment_moderation_headers', array( $this, 'comment_email_headers' ) );
+		\add_filter( 'comment_notification_headers', [ $this, 'comment_email_headers' ] );
+		\add_filter( 'comment_moderation_headers', [ $this, 'comment_email_headers' ] );
 	}
 
 	/**
@@ -226,12 +226,12 @@ class Clean_Emails {
 	 * Returns a string containing comment moderation links.
 	 */
 	private function comment_moderation_actions() {
-		$actions = array(
+		$actions = [
 			'approve'     => \__( 'Approve', 'yoast-comment-hacks' ),
 			'spam'        => \__( 'Spam', 'yoast-comment-hacks' ),
 			'trash'       => \__( 'Trash', 'yoast-comment-hacks' ),
 			'editcomment' => \__( 'Edit', 'yoast-comment-hacks' ),
-		);
+		];
 
 		$this->comment_action_links( $actions );
 	}
@@ -240,11 +240,11 @@ class Clean_Emails {
 	 * Returns a string containing comment action links.
 	 */
 	private function comment_notification_actions() {
-		$actions = array(
+		$actions = [
 			'spam'        => \__( 'Spam', 'yoast-comment-hacks' ),
 			'trash'       => \__( 'Trash', 'yoast-comment-hacks' ),
 			'editcomment' => \__( 'Edit', 'yoast-comment-hacks' ),
-		);
+		];
 
 		$this->comment_action_links( $actions );
 	}

--- a/inc/email-links.php
+++ b/inc/email-links.php
@@ -16,7 +16,7 @@ class Email_Links {
 	 *
 	 * @var array
 	 */
-	private $options = array();
+	private $options = [];
 
 	/**
 	 * Class constructor.
@@ -24,7 +24,7 @@ class Email_Links {
 	public function __construct() {
 		$this->options = Hacks::get_options();
 
-		\add_action( 'init', array( $this, 'init' ) );
+		\add_action( 'init', [ $this, 'init' ] );
 	}
 
 	/**
@@ -33,12 +33,12 @@ class Email_Links {
 	public function init() {
 		if ( \is_admin() ) {
 			// Adds the email link to the actions on the comment overview page.
-			\add_filter( 'comment_row_actions', array( $this, 'add_mailto_action_row' ) );
+			\add_filter( 'comment_row_actions', [ $this, 'add_mailto_action_row' ] );
 
 			return;
 		}
-		\add_action( 'admin_bar_menu', array( $this, 'admin_bar_comment_link' ), 65 );
-		\add_action( 'wp_head', array( $this, 'wp_head_css' ) );
+		\add_action( 'admin_bar_menu', [ $this, 'admin_bar_comment_link' ], 65 );
+		\add_action( 'wp_head', [ $this, 'wp_head_css' ] );
 	}
 
 	/**
@@ -79,12 +79,12 @@ class Email_Links {
 		</script>';
 
 		$wp_admin_bar->add_menu(
-			array(
+			[
 				'id'    => 'yst-email-commenters',
 				'title' => '<span class="ab-icon" title="' . \__( 'Email commenters', 'yoast-comment-hacks' ) . '"></span>',
 				'href'  => '#',
-				'meta'  => array( 'onclick' => 'yst_email_commenters(event)' ),
-			)
+				'meta'  => [ 'onclick' => 'yst_email_commenters(event)' ],
+			]
 		);
 	}
 
@@ -131,10 +131,10 @@ class Email_Links {
 		$left_actions  = \array_slice( $actions, 0, 5 );
 		$right_actions = \array_slice( $actions, 5 );
 
-		$new_action = array(
+		$new_action = [
 			/* translators: %s is replaced with the comment authors name */
 			'mailto' => '<a href="' . \esc_attr( $link ) . '"><span class="dashicons dashicons-email-alt"></span> ' . \esc_html( \sprintf( \__( 'E-mail %s', 'yoast-comment-hacks' ), $comment->comment_author ) ) . '</a>',
-		);
+		];
 
 		return \array_merge( $left_actions, $new_action, $right_actions );
 	}
@@ -164,10 +164,10 @@ class Email_Links {
 
 		$replacements = \array_merge(
 			$replacements,
-			array(
+			[
 				'title'     => $post->post_title,
 				'permalink' => \get_permalink( $post->ID ),
-			)
+			]
 		);
 
 		foreach ( $replacements as $key => $value ) {
@@ -185,22 +185,22 @@ class Email_Links {
 	 * @return array
 	 */
 	private function get_replacements( $comment ) {
-		$replacements = array(
+		$replacements = [
 			'email'     => '',
 			'firstname' => '',
 			'name'      => '',
 			'url'       => '',
-		);
+		];
 
 		if ( \is_object( $comment ) ) {
 			$name = \explode( ' ', $comment->comment_author );
 
-			$replacements = array(
+			$replacements = [
 				'email'     => $comment->comment_author_email,
 				'firstname' => $name[0],
 				'name'      => $comment->comment_author,
 				'url'       => $comment->comment_author_url,
-			);
+			];
 		}
 
 		return $replacements;

--- a/inc/forms.php
+++ b/inc/forms.php
@@ -17,7 +17,7 @@ class Forms {
 	 *
 	 * @var array
 	 */
-	private $options = array();
+	private $options = [];
 
 	/**
 	 * Class constructor.
@@ -25,7 +25,7 @@ class Forms {
 	public function __construct() {
 		$this->options = Hacks::get_options();
 
-		\add_filter( 'comment_form_defaults', array( $this, 'filter_defaults' ) );
+		\add_filter( 'comment_form_defaults', [ $this, 'filter_defaults' ] );
 	}
 
 	/**

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -29,7 +29,7 @@ class Hacks {
 	 *
 	 * @var array
 	 */
-	private $options = array();
+	private $options = [];
 
 	/**
 	 * Class constructor.
@@ -39,10 +39,10 @@ class Hacks {
 		$this->set_defaults();
 		$this->upgrade();
 
-		\add_action( 'init', array( $this, 'load_text_domain' ) );
+		\add_action( 'init', [ $this, 'load_text_domain' ] );
 
 		// Filter the redirect URL.
-		\add_filter( 'comment_post_redirect', array( $this, 'comment_redirect' ), 10, 2 );
+		\add_filter( 'comment_post_redirect', [ $this, 'comment_redirect' ], 10, 2 );
 
 		if ( $this->options['clean_emails'] ) {
 			new Clean_Emails();
@@ -79,11 +79,11 @@ class Hacks {
 	 */
 	public function comment_redirect( $url, $comment ) {
 		$has_approved_comment = \get_comments(
-			array(
+			[
 				'author_email' => $comment->comment_author_email,
 				'number'       => 1,
 				'status'       => 'approve',
-			)
+			]
 		);
 
 		// If no approved comments have been found, show the thank-you page.
@@ -103,7 +103,7 @@ class Hacks {
 				 */
 				$url = \apply_filters_deprecated(
 					'yoast_comment_redirect',
-					array( $url, $comment ),
+					[ $url, $comment ],
 					'Yoast Comment 1.6.0',
 					'Yoast\WP\Comment\redirect'
 				);
@@ -147,7 +147,7 @@ class Hacks {
 	 * @since 1.0
 	 */
 	private function upgrade() {
-		foreach ( array( 'MinComLengthOptions', 'min_comment_length_option', 'CommentRedirect' ) as $old_option ) {
+		foreach ( [ 'MinComLengthOptions', 'min_comment_length_option', 'CommentRedirect' ] as $old_option ) {
 			$old_option_values = $this->get_option_from_cache( $old_option );
 			if ( \is_array( $old_option_values ) ) {
 				if ( isset( $old_option_values['page'] ) ) {
@@ -173,7 +173,7 @@ class Hacks {
 	 * @return array
 	 */
 	public static function get_defaults() {
-		return array(
+		return [
 			'clean_emails'      => true,
 			/* translators: %s expands to the post title */
 			'email_subject'     => \sprintf( \__( 'RE: %s', 'yoast-comment-hacks' ), '%title%' ),
@@ -186,7 +186,7 @@ class Hacks {
 			'maxcomlength'      => 1500,
 			'maxcomlengtherror' => \__( 'Error: Your comment is too long. Please try to be more concise.', 'yoast-comment-hacks' ),
 			'redirect_page'     => 0,
-		);
+		];
 	}
 
 	/**

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -96,10 +96,28 @@ class Hacks {
 				 * Allow other plugins to hook in when the user is being redirected,
 				 * for analytics calls or even to change the target URL.
 				 *
+				 * @deprecated 1.6.0. Use the {@see 'Yoast\WP\Comment\redirect'} filter instead.
+				 *
 				 * @param string $url     URL to which the first-time commenter will be redirected.
 				 * @param object $comment The comment object.
 				 */
-				$url = \apply_filters( 'yoast_comment_redirect', $url, $comment );
+				$url = \apply_filters_deprecated(
+					'yoast_comment_redirect',
+					array( $url, $comment ),
+					'Yoast Comment 1.6.0',
+					'Yoast\WP\Comment\redirect'
+				);
+
+				/**
+				 * Allow other plugins to hook in when the user is being redirected,
+				 * for analytics calls or even to change the target URL.
+				 *
+				 * @since 1.6.0
+				 *
+				 * @param string $url     URL to which the first-time commenter will be redirected.
+				 * @param object $comment The comment object.
+				 */
+				$url = \apply_filters( 'Yoast\WP\Comment\redirect', $url, $comment );
 			}
 		}
 

--- a/inc/length.php
+++ b/inc/length.php
@@ -17,7 +17,7 @@ class Length {
 	 *
 	 * @var array
 	 */
-	private $options = array();
+	private $options = [];
 
 	/**
 	 * Class constructor.
@@ -26,7 +26,7 @@ class Length {
 		$this->options = Hacks::get_options();
 
 		// Process the comment and check it for length.
-		\add_filter( 'preprocess_comment', array( $this, 'check_comment_length' ) );
+		\add_filter( 'preprocess_comment', [ $this, 'check_comment_length' ] );
 	}
 
 	/**

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -14,10 +14,10 @@ class Notifications {
 	 * Class constructor.
 	 */
 	public function __construct() {
-		\add_filter( 'comment_notification_recipients', array( $this, 'filter_notification_recipients' ), 10, 2 );
-		\add_filter( 'comment_moderation_recipients', array( $this, 'filter_notification_recipients' ), 10, 2 );
-		\add_filter( 'comment_notification_headers', array( $this, 'filter_notification_headers' ), 10, 2 );
-		\add_filter( 'comment_moderation_headers', array( $this, 'filter_notification_headers' ), 10, 2 );
+		\add_filter( 'comment_notification_recipients', [ $this, 'filter_notification_recipients' ], 10, 2 );
+		\add_filter( 'comment_moderation_recipients', [ $this, 'filter_notification_recipients' ], 10, 2 );
+		\add_filter( 'comment_notification_headers', [ $this, 'filter_notification_headers' ], 10, 2 );
+		\add_filter( 'comment_moderation_headers', [ $this, 'filter_notification_headers' ], 10, 2 );
 	}
 
 	/**
@@ -36,7 +36,7 @@ class Notifications {
 		if ( ! empty( $new_recipient ) ) {
 			$user = \get_userdata( $new_recipient );
 
-			return array( $user->user_email );
+			return [ $user->user_email ];
 		}
 
 		return $recipients;


### PR DESCRIPTION
### PHPCS: Update to YoastCS 2.0.0

This updates the dependency in `composer.json`, as well as the PHPCS ruleset for YoastCS 2.0.0.

Includes:
* A selective update of the `composer.lock` for just YoastCS and its dependencies.
* Removing the tweaks to the Composer `check-cs` script to allow for PHP >= 5.6.
    PHP 5.6 is now the minimum PHP version everywhere.

Ref: https://github.com/Yoast/yoastcs/releases/tag/2.0.0

### CS: deprecate old-style hook and add new-style hook [1]

This deprecates the `yoast_comment_hacks_notification_roles` filter hook in favour of the `Yoast\WP\Comment\notification_roles` hook.

[This needs a changelog entry]

### CS: deprecate old-style hook and add new-style hook [2]

This deprecates the `yoast_ch_admin_footer` action hook in favour of the `Yoast\WP\Comment\admin_footer` hook.

[This needs a changelog entry]

### CS: deprecate old-style hook and add new-style hook [3]

This deprecates the `yoast_comment_redirect` filter hook in favour of the `Yoast\WP\Comment\redirect` hook.

[This needs a changelog entry]

### CS: use short arrays (everywhere) 

## Testing

See the test instructions in the Yoast/wpseo-woocommerce#451 PR for guidance on how to test this PR.