### PR TITLE
Fix js loading / allow for script debug

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -100,7 +100,7 @@ class Admin {
 
 			\wp_enqueue_script(
 				'yoast-comment-hacks-admin-js',
-				\plugins_url( 'admin/assets/js/yoast-comment-hacks.min.js', \YOAST_COMMENT_HACKS_FILE ),
+				\plugins_url( 'admin/assets/js/yoast-comment-hacks' . $min . '.js', \YOAST_COMMENT_HACKS_FILE ),
 				[],
 				\YOAST_COMMENT_HACKS_VERSION,
 				true


### PR DESCRIPTION
The code was already in place to load the minified vs non-minified file based on whether `SCRIPT_DEBUG` is set or not, the `$min` variable just wasn't used.

## Testing

To test this change:
* Define the constant `SCRIPT_DEBUG` in `wp-config.php` and set it to `true`.
* While on `trunk`, load the comment hacks admin page.
* Do a "view source" on the JS file and see a minified unreadable mess.
* Switch to this branch, reload the admin page.
* Check the JS source again and you should see human readable output.

Note: I haven't tested this and these test instructions presume that grunt build has been run and the minified file exists (then again, the original code also presumed that).