### PR TITLE
QA: remove unused private property

### DIFF
--- a/inc/forms.php
+++ b/inc/forms.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\Comment\Inc;
 
-use Yoast\WP\Comment\Inc\Hacks;
-
 /**
  * Add comment note.
  *
@@ -13,18 +11,9 @@ use Yoast\WP\Comment\Inc\Hacks;
 class Forms {
 
 	/**
-	 * Holds the plugins options.
-	 *
-	 * @var array
-	 */
-	private $options = [];
-
-	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
-		$this->options = Hacks::get_options();
-
 		\add_filter( 'comment_form_defaults', [ $this, 'filter_defaults' ] );
 	}
 


### PR DESCRIPTION
As the property is not used by this class, setting it is redundant.