### PR TITLE
Docs: various minor fixes

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -196,7 +196,7 @@ class Admin {
 	 *
 	 * @param array $input Input with unvalidated options.
 	 *
-	 * @return array $input Validated input.
+	 * @return array Validated input.
 	 */
 	public function options_validate( $input ) {
 		$defaults = Hacks::get_defaults();

--- a/inc/clean-emails.php
+++ b/inc/clean-emails.php
@@ -53,7 +53,7 @@ class Clean_Emails {
 	 *
 	 * @param string $message_headers The message headers for the comment email.
 	 *
-	 * @return string $message_headers
+	 * @return string
 	 */
 	public function comment_email_headers( $message_headers ) {
 		if ( $message_headers === '' ) {
@@ -69,7 +69,7 @@ class Clean_Emails {
 	 * @param string $message    The comment notification message.
 	 * @param int    $comment_id The ID of the comment the notification is for.
 	 *
-	 * @return string $message
+	 * @return string
 	 */
 	public function comment_notification_text( $message, $comment_id ) {
 		$this->setup_data( $comment_id );
@@ -103,7 +103,7 @@ class Clean_Emails {
 	 * @param string $message    The comment moderation message.
 	 * @param int    $comment_id The ID of the comment the moderation notification is for.
 	 *
-	 * @return string $message
+	 * @return string
 	 */
 	public function comment_moderation_text( $message, $comment_id ) {
 		$this->setup_data( $comment_id );

--- a/inc/email-links.php
+++ b/inc/email-links.php
@@ -142,9 +142,9 @@ class Email_Links {
 	/**
 	 * Replace variables with values in the message.
 	 *
-	 * @param string         $msg     The message in which we're replacing variables.
-	 * @param boolean|object $comment The comment object.
-	 * @param int|boolean    $post    The post the comment belongs to.
+	 * @param string      $msg     The message in which we're replacing variables.
+	 * @param bool|object $comment The comment object.
+	 * @param int|bool    $post    The post the comment belongs to.
 	 *
 	 * @return string
 	 */
@@ -180,7 +180,7 @@ class Email_Links {
 	/**
 	 * Getting the replacements with comment data if there is a comment.
 	 *
-	 * @param boolean|object $comment The comment object.
+	 * @param bool|object $comment The comment object.
 	 *
 	 * @return array
 	 */

--- a/inc/email-links.php
+++ b/inc/email-links.php
@@ -115,7 +115,7 @@ class Email_Links {
 	 *
 	 * @param array $actions Array of actions we'll be adding our action to.
 	 *
-	 * @return array $actions
+	 * @return array
 	 */
 	public function add_mailto_action_row( $actions ) {
 		global $comment;
@@ -146,7 +146,7 @@ class Email_Links {
 	 * @param boolean|object $comment The comment object.
 	 * @param int|boolean    $post    The post the comment belongs to.
 	 *
-	 * @return string $msg
+	 * @return string
 	 */
 	private function replace_variables( $msg, $comment = false, $post = false ) {
 		$replacements = $this->get_replacements( $comment );

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -75,7 +75,7 @@ class Hacks {
 	 * @param string $url     The original redirect URL.
 	 * @param object $comment The comment object.
 	 *
-	 * @return string $url the URL to be redirected to, altered if this was a first time comment.
+	 * @return string The URL to be redirected to, altered if this was a first time comment.
 	 */
 	public function comment_redirect( $url, $comment ) {
 		$has_approved_comment = \get_comments(

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -127,9 +127,9 @@ class Hacks {
 	/**
 	 * See if the option has been cached, if it is, return it, otherwise return false.
 	 *
-	 * @param string $option The option to check for.
-	 *
 	 * @since 1.3
+	 *
+	 * @param string $option The option to check for.
 	 *
 	 * @return bool|mixed
 	 */

--- a/inc/length.php
+++ b/inc/length.php
@@ -36,7 +36,7 @@ class Length {
 	 *
 	 * @param array $comment_data All the data for the comment.
 	 *
-	 * @return array $comment_data All the data for the comment (only returned when the comment is long enough).
+	 * @return array All the data for the comment (only returned when the comment is long enough).
 	 */
 	public function check_comment_length( $comment_data ) {
 		// Bail early for editors and admins, they can leave short or long comments if they want.


### PR DESCRIPTION
### Docs: fix return tags 

PHP has no concept of named return variables, so the name of the variable has no value in the `@return` tag.

### Docs: use short form types

### Docs: fix tag order