### PR TITLE
CS: revert "always use `use` statements"

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -2,7 +2,6 @@
 
 namespace Yoast\WP\Comment\Admin;
 
-use Yoast\WP\Comment\Admin\Comment_Parent;
 use Yoast\WP\Comment\Inc\Hacks;
 use Yoast_I18n_WordPressOrg_v3;
 

--- a/inc/email-links.php
+++ b/inc/email-links.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\Comment\Inc;
 
-use Yoast\WP\Comment\Inc\Hacks;
-
 /**
  * Manage links in comments.
  *

--- a/inc/hacks.php
+++ b/inc/hacks.php
@@ -3,11 +3,6 @@
 namespace Yoast\WP\Comment\Inc;
 
 use Yoast\WP\Comment\Admin\Admin;
-use Yoast\WP\Comment\Inc\Clean_Emails;
-use Yoast\WP\Comment\Inc\Email_Links;
-use Yoast\WP\Comment\Inc\Forms;
-use Yoast\WP\Comment\Inc\Length;
-use Yoast\WP\Comment\Inc\Notifications;
 
 /**
  * Main comment hacks functionality.

--- a/inc/length.php
+++ b/inc/length.php
@@ -2,8 +2,6 @@
 
 namespace Yoast\WP\Comment\Inc;
 
-use Yoast\WP\Comment\Inc\Hacks;
-
 /**
  * Checks the comments for allowed length.
  *


### PR DESCRIPTION
Import `use` statements for classes in the same namespace will not be allowed.