### PR TITLE
Travis: change from "trusty" to "xenial"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+os: linux
 language: php
-dist: trusty
 
 branches:
   only:
@@ -55,7 +55,6 @@ before_script:
   - export -f travis_fold
   - export -f travis_time_start
   - export -f travis_time_finish
-  - mysql --version
   - phpenv versions
   - php --version
   - php -m


### PR DESCRIPTION
As the "trusty" environment is no longer officially supported by Travis, let's remove the key which will let the script use the default distro - currently `xenial`.

This updates the Travis config to:
* Makes the expected OS explicit (linux).
* Removes `--mysql --version`.
    MySQL is not installed by default on the `xenial` platform. It can be installed when needed by setting it in `services`, but the Comment Hacks plugin doesn't _need_ it for the currently setup CI checks.