### PR TITLE
Adjust comment type checks for WP 5.5 and later.

### DIFF
--- a/inc/clean-emails.php
+++ b/inc/clean-emails.php
@@ -147,7 +147,7 @@ class Clean_Emails {
 	 * Adds the author line to the message.
 	 */
 	private function add_author_line() {
-		if ( $this->comment->comment_type === '' ) {
+		if ( $this->comment->comment_type === 'comment' ) {
 			/* translators: %1$s is replaced with the comment author's name, %2$s is replaced with the comment author's email */
 			$this->message .= \sprintf( \__( 'Author: %1$s (%2$s)', 'yoast-comment-hacks' ), \esc_html( $this->comment->comment_author ), '<a href="' . \esc_url( 'mailto:' . $this->comment->comment_author_email ) . '">' . \esc_html( $this->comment->comment_author_email ) . '</a>' ) . '<br />';
 		}
@@ -161,7 +161,7 @@ class Clean_Emails {
 	 * Adds the content line to the message.
 	 */
 	private function add_content_line() {
-		if ( $this->comment->comment_type === '' ) {
+		if ( $this->comment->comment_type === 'comment' ) {
 			$this->message .= \__( 'Comment:', 'yoast-comment-hacks' );
 		}
 		else {
@@ -199,10 +199,6 @@ class Clean_Emails {
 		$this->comment_id = $comment_id;
 		$this->comment    = \get_comment( $this->comment_id );
 		$this->post       = \get_post( $this->comment->comment_post_ID );
-
-		if ( $this->comment->comment_type === 'comment' ) {
-			$this->comment->comment_type = '';
-		}
 	}
 
 	/**

--- a/inc/email-links.php
+++ b/inc/email-links.php
@@ -51,7 +51,7 @@ class Email_Links {
 
 		$current_user = \wp_get_current_user();
 
-		$results = $wpdb->get_results( $wpdb->prepare( "SELECT DISTINCT comment_author_email FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_type = '' AND comment_approved = '1'", $post->ID ) );
+		$results = $wpdb->get_results( $wpdb->prepare( "SELECT DISTINCT comment_author_email FROM $wpdb->comments WHERE comment_post_ID = %d AND comment_type = 'comment' AND comment_approved = '1'", $post->ID ) );
 
 		if ( \count( $results ) === 0 ) {
 			return;
@@ -118,7 +118,7 @@ class Email_Links {
 	public function add_mailto_action_row( $actions ) {
 		global $comment;
 
-		if ( $comment->comment_type !== '' ) {
+		if ( $comment->comment_type !== 'comment' ) {
 			return $actions;
 		}
 

--- a/inc/email-links.php
+++ b/inc/email-links.php
@@ -71,8 +71,12 @@ class Email_Links {
 		// so browser extensions like the Google Mail one that change mailto: links still work.
 		echo '<a href="' . \esc_attr( $url ) . '" id="yst_email_commenters_alternate"></a><script>
 			function yst_email_commenters(e){
+				var ystEmailCommentersLink = document.getElementById( "yst_email_commenters_alternate" );
 				e.preventDefault();
-				window.location = jQuery(\'#yst_email_commenters_alternate\').attr(\'href\');
+				if ( ystEmailCommentersLink === null ) {
+					return;
+				}
+				window.location = ystEmailCommentersLink.getAttribute( "href" );
 			}
 		</script>';
 


### PR DESCRIPTION
In WordPress 5.5, the default `comment_type` was changed from an empty string to `comment`. This had some impact for all the features that still had checks in place for an empty string. This PR just updates a few places in the codebase where an empty string was assumed to be the value for a `comment_type of type` "comment".

## Relevant technical choices:
The changes in this PR are based on two assumptions that look legitimate:
- No need for backward compatibility. The change in WordPress 5.5 also introduced an upgrade routine to update all `content_type` empty strings to `comment`. See the related change: https://core.trac.wordpress.org/changeset/47597. The upgrade routine ran on a scheduled event. WordPress 5.5 was released on August 11, 2020 and it's safe to assume this value has been on all 5.5 installations out there.
- Looking at the Comment Hacks readme, the plugin only supports WordPress the last two WordPress versions anyways. It requires at least 5.6, where the `comment_type` value is `comment`.


## Changelog entry

* Fixes a bug where the "Email commenters" link wasn't displayed any longer in the WordPress admin bar and in the Comments list.
* Fixes a bug where the "Email commenters" link in the front end admin bar didn't work when jQuery isn't enqueued.
* Fixes a bug where the notification emails for new comments had wrong content for the Author line and the text displayed before the comment.

## Test instructions

- install and activate Comment Hacks (switched to this branch and built)
- **deactivate any other plugin**
- go to the front end and view a post that has at least one comment
- check that in the WordPress admin a link with an email icon is displayed:

<img width="619" alt="Screenshot 2021-04-14 at 15 38 39" src="https://user-images.githubusercontent.com/1682452/114719619-8f6d5000-9d37-11eb-881a-d27307dce16e.png">

- click the link and check that your email client should open with a pre-filled email:
  - the "To" field is pre-filled with the email for your current user
  - the "Bcc" field is pre-filled with the emails of all the users who commented on the post
  - the "Subject" field is prefilled with "RE: {post name}"
  - the mail body is prefilled with "Hi, {new line} I'm sending you all this email because you commented on my post ..."
 - close your email client
 - go to the WP admin > Comments 
 - mouse-hover on a comment row and check there's an email link within the links that appear on hovering
 - check the link has a mail icon and text "E-mail {commenter's name}"
 - click the link and check that your email client should open with a pre-filled email:
   - "To": the commenter's email
   - Subject: "RE: {post name}"
   - Body: "Hi {commenter's name}, {new line} I'm emailing you because you commented on my post "Hello world!" ..."
- in the Comments list, check that hovering a pingback or trackback row (the Docker environment adds some of them by default), no email link is displayed 
- go to the WP admin > Settings > Discussion and make sure that;
  - "Allow people to submit comments on new posts" is checked
  - "Comment author must fill out name and email" is checked
  - "A comment is held for moderation" is checked
  - all other settings related to the ability to post comments is NOT checked
- open an incognito tab, view a post in the front end and add a comment
- by using Mailhog in the Docker environment (http://localhost:8025/) check the notification email that informs there's a new comment awaiting moderation
- check that in the email body the line related to the comment author is, for example: "Author: Andrea Fercia (andrea@yoast.com)"
- check the part related to the comment content starts with a line that says "Comment:"
- note: we need to check this because for `comment_type` that are pingbacks or trackbacks, those two lines are different ("Website" instead of "Author" and "Excerpt" instead of "Comment")
- check the first line of the body is "A new comment on the post {post title} is waiting for your approval:"
- check the email format matches the comment moderation email in the screenshot below:

<img width="856" alt="comment hacks moderation email" src="https://user-images.githubusercontent.com/1682452/114732185-9baada80-9d42-11eb-90f8-4525f83041a5.png">

- go to the WP admin > Settings > Discussion and uncheck all checkboxes under "Before a comment appears"
- open an incognito tab, view a post in the front end and add a new comment
- the comment should be published right away, with no moderation
- following the instructions above, check the notification email that informs a new comment
- check the author line and the comment line are correct, as explained above
- check the first line fo the body is "New comment on {post title}"
- check the email format matches the new comment email in the screenshot below:

<img width="863" alt="comment hacks no moderation email" src="https://user-images.githubusercontent.com/1682452/114732979-402d1c80-9d43-11eb-9060-8734bcb08be6.png">

Fixes [P3-519]
Fixes https://github.com/Yoast/comment-hacks/issues/76