### PR TITLE
Set tested up to version to 5.8

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: joostdevalk, yoast
 Tags: comments, spam, emails
 Text Domain: yoast-comment-hacks
 Requires at least: 5.6
-Tested up to: 5.7
+Tested up to: 5.8
 Stable tag: 1.7
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
WordPress 5.8 is released on July 20th. This PR sets the tested up to version to 5.8.