### PR TITLE
Travis: remove nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,7 @@ jobs:
       env: PHPLINT=1 CHECK=1 PHPCS=1 TRAVIS_NODE_VERSION=node
     - php: 5.6
       env: PHPLINT=1
-    - php: "nightly"
-      env: PHPLINT=1
-  allow_failures:
-    # Allow failures for unstable builds.
-    - php: "nightly"
+    - php: 8.0
       env: PHPLINT=1
 
 cache:
@@ -40,9 +36,7 @@ before_install:
 
 install:
   - |
-    if [[ $TRAVIS_PHP_VERSION == "nightly" && "$PHPLINT" == "1" ]]; then
-      composer install --no-interaction --ignore-platform-reqs
-    elif [[ "$CHECK" == "1" || "$PHPCS" == "1" || "$PHPLINT" == "1" ]]; then
+    if [[ "$CHECK" == "1" || "$PHPCS" == "1" || "$PHPLINT" == "1" ]]; then
       composer install --no-interaction
     fi
   - |


### PR DESCRIPTION
At this time, the current PHP 8.0 version is `8.0.11`. The Travis PHP `8.0` image yields PHP `8.0.9`, which is good enough for PHP 8.0.

`nightly` however is PHP `8.0.3` and hasn't been updated since Feb 2021, so running tests against that image is completely useless at this time.

Notes:
    * Tested `nightly` against all relevant `dist`s - `xenial`, `bionic` and `focal` and none have a more current image.
    * The [PHP Build project](https://github.com/php-build/php-build/tree/master/share/php-build/definitions), which Travis pulls its images from, _does_ have a PHP `8.1snapshot` image available.
        I've tested to see if that image is available on Travis, but unfortunately, no luck there either.

Includes removing a redundant condition - that condition was applicable when there were still dependencies which did not allow for installing on PHP 8.0, but that no longer applies.