### PR TITLE
GH Actions: minor tweaks

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -39,7 +39,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       # Check the codestyle of the files.
       # The results of the CS check will be shown inline in the PR via the CS2PR tool.

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v2
 
       # The ubuntu images come with Node, npm and yarn pre-installed.
-      # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
+      # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
 
       # This action also handles the caching of the Yarn dependencies.
       # https://github.com/actions/setup-node

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up node and enable caching of dependencies
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: '14'
           cache: 'yarn'
 
       - name: Yarn install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Lint against parse errors
         run: composer lint -- --checkstyle | cs2pr

--- a/grunt/config/shell.js
+++ b/grunt/config/shell.js
@@ -2,11 +2,11 @@
 module.exports = function() {
 	return {
 		"composer-install-production": {
-			command: "composer install --prefer-dist --optimize-autoloader --no-dev",
+			command: "composer install --prefer-dist --optimize-autoloader --no-dev --no-interaction",
 		},
 
 		"composer-install-dev": {
-			command: "composer install",
+			command: "composer install --no-interaction",
 		},
 
 		"composer-reset-config": {


### PR DESCRIPTION
### GH Actions: version update for ramsey/composer-install

The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Refs:
* https://github.com/ramsey/composer-install/releases/

### GH Actions: minor type safety improvement

### Grunt/shell: always use --no-interaction for Composer

As these scripts are supposed to be run "under the hood" in both local dev, as well as CI, adding `--no-interaction` to Composer commands to potentially prevent CI hanging if, for whatever reason, interaction would be needed in the future.

### GH Actions: fix broken link 

(used in inline script documentation)