### PR TITLE
Sets minimum WordPress version to 5.9 and tested up to 6.0.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         include:
           - php_version: '5.6'
-            wp_version: '5.8'
+            wp_version: '5.9'
             multisite: true
 
           - php_version: '7.0'
@@ -34,7 +34,7 @@ jobs:
             multisite: false
 
           - php_version: '7.2'
-            wp_version: '5.8'
+            wp_version: '5.9'
             multisite: false
 
           - php_version: '7.3'
@@ -42,7 +42,7 @@ jobs:
             multisite: true
 
           - php_version: '7.4'
-            wp_version: '5.8'
+            wp_version: '5.9'
             multisite: false
 
           # WP 5.6 is the earliest version which (sort of) supports PHP 8.0.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: joostdevalk, yoast
 Tags: comments, spam, emails
 Text Domain: yoast-comment-hacks
-Requires at least: 5.8
-Tested up to: 5.9
+Requires at least: 5.9
+Tested up to: 6.0
 Stable tag: 1.7
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Sets minimum WordPress version to 5.9 and tested up to 6.0.